### PR TITLE
Add Dashboard Webhook Sync for Real-Time Guild Updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ LOGS_WEBHOOK=
 # Dashboard [Required for dashboard]
 CLIENT_SECRET=
 SESSION_PASSWORD=
+BASE_URL= # Dashboard URL (e.g., https://yoursite.com or http://localhost:4321)
+WEBHOOK_SECRET= # Secure random string for dashboard webhook authentication
 
 # Required for Weather Command (https://weatherstack.com)
 WEATHERSTACK_KEY=

--- a/src/events/guild/guildCreate.js
+++ b/src/events/guild/guildCreate.js
@@ -27,11 +27,11 @@ module.exports = async (client, guild) => {
     await guildSettings.save()
   }
 
-  // Notify dashboard via webhook
+  // Notify dashboard to refresh guild data
   if (process.env.BASE_URL && process.env.WEBHOOK_SECRET) {
     try {
       const response = await fetch(
-        `${process.env.BASE_URL}/api/guild-sync`,
+        `${process.env.BASE_URL}/api/guild/refresh`,
         {
           method: 'POST',
           headers: {
@@ -39,24 +39,22 @@ module.exports = async (client, guild) => {
             Authorization: `Bearer ${process.env.WEBHOOK_SECRET}`,
           },
           body: JSON.stringify({
-            event: 'guildCreate',
             guildId: guild.id,
-            timestamp: new Date().toISOString(),
           }),
         }
       )
 
       if (response.ok) {
-        console.log('✅ Dashboard notified of guild join')
+        console.log('✅ Dashboard cache refreshed for guild join')
       } else {
         console.error(
-          '⚠️ Dashboard webhook failed:',
+          '⚠️ Dashboard refresh failed:',
           response.status,
           await response.text()
         )
       }
     } catch (err) {
-      console.error('❌ Failed to notify dashboard of guild join:', err.message)
+      console.error('❌ Failed to refresh dashboard cache:', err.message)
     }
   }
 

--- a/src/events/guild/guildCreate.js
+++ b/src/events/guild/guildCreate.js
@@ -8,6 +8,7 @@ const {
   ChannelType,
 } = require('discord.js')
 const { EMBED_COLORS } = require('@src/config')
+const { notifyDashboard } = require('@helpers/webhook')
 
 /**
  * @param {import('@src/structures').BotClient} client
@@ -28,35 +29,7 @@ module.exports = async (client, guild) => {
   }
 
   // Notify dashboard to refresh guild data
-  if (process.env.BASE_URL && process.env.WEBHOOK_SECRET) {
-    try {
-      const response = await fetch(
-        `${process.env.BASE_URL}/api/guild/refresh`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${process.env.WEBHOOK_SECRET}`,
-          },
-          body: JSON.stringify({
-            guildId: guild.id,
-          }),
-        }
-      )
-
-      if (response.ok) {
-        console.log('✅ Dashboard cache refreshed for guild join')
-      } else {
-        console.error(
-          '⚠️ Dashboard refresh failed:',
-          response.status,
-          await response.text()
-        )
-      }
-    } catch (err) {
-      console.error('❌ Failed to refresh dashboard cache:', err.message)
-    }
-  }
+  await notifyDashboard(client, guild.id, 'join')
 
   // Check for existing invite link or create a new one
   let inviteLink = guildSettings.server.invite_link

--- a/src/events/guild/guildCreate.js
+++ b/src/events/guild/guildCreate.js
@@ -28,8 +28,8 @@ module.exports = async (client, guild) => {
     await guildSettings.save()
   }
 
-  // Notify dashboard to refresh guild data
-  await notifyDashboard(client, guild.id, 'join')
+  // Notify dashboard to refresh guild data (fire-and-forget)
+  notifyDashboard(client, guild.id, 'join')
 
   // Check for existing invite link or create a new one
   let inviteLink = guildSettings.server.invite_link

--- a/src/events/guild/guildDelete.js
+++ b/src/events/guild/guildDelete.js
@@ -19,8 +19,8 @@ module.exports = async (client, guild) => {
   settings.server.leftAt = new Date()
   await settings.save()
 
-  // Notify dashboard to refresh guild data
-  await notifyDashboard(client, guild.id, 'leave')
+  // Notify dashboard to refresh guild data (fire-and-forget)
+  notifyDashboard(client, guild.id, 'leave')
 
   let ownerTag = 'Deleted User'
   const ownerId = guild.ownerId || settings.server.owner

--- a/src/events/guild/guildDelete.js
+++ b/src/events/guild/guildDelete.js
@@ -18,11 +18,11 @@ module.exports = async (client, guild) => {
   settings.server.leftAt = new Date()
   await settings.save()
 
-  // Notify dashboard via webhook
+  // Notify dashboard to refresh guild data
   if (process.env.BASE_URL && process.env.WEBHOOK_SECRET) {
     try {
       const response = await fetch(
-        `${process.env.BASE_URL}/api/guild-sync`,
+        `${process.env.BASE_URL}/api/guild/refresh`,
         {
           method: 'POST',
           headers: {
@@ -30,24 +30,22 @@ module.exports = async (client, guild) => {
             Authorization: `Bearer ${process.env.WEBHOOK_SECRET}`,
           },
           body: JSON.stringify({
-            event: 'guildDelete',
             guildId: guild.id,
-            timestamp: new Date().toISOString(),
           }),
         }
       )
 
       if (response.ok) {
-        console.log('✅ Dashboard notified of guild leave')
+        console.log('✅ Dashboard cache refreshed for guild leave')
       } else {
         console.error(
-          '⚠️ Dashboard webhook failed:',
+          '⚠️ Dashboard refresh failed:',
           response.status,
           await response.text()
         )
       }
     } catch (err) {
-      console.error('❌ Failed to notify dashboard of guild leave:', err.message)
+      console.error('❌ Failed to refresh dashboard cache:', err.message)
     }
   }
 

--- a/src/events/guild/guildDelete.js
+++ b/src/events/guild/guildDelete.js
@@ -5,12 +5,13 @@ const {
   ButtonStyle,
 } = require('discord.js')
 const { getSettings } = require('@schemas/Guild')
+const { notifyDashboard } = require('@helpers/webhook')
 
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 module.exports = async (client, guild) => {
   if (!guild.available) return
-  console.log(
+  client.logger.log(
     `Guild Left: ${guild.name} (${guild.id}) Members: ${guild.memberCount}`
   )
 
@@ -19,35 +20,7 @@ module.exports = async (client, guild) => {
   await settings.save()
 
   // Notify dashboard to refresh guild data
-  if (process.env.BASE_URL && process.env.WEBHOOK_SECRET) {
-    try {
-      const response = await fetch(
-        `${process.env.BASE_URL}/api/guild/refresh`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${process.env.WEBHOOK_SECRET}`,
-          },
-          body: JSON.stringify({
-            guildId: guild.id,
-          }),
-        }
-      )
-
-      if (response.ok) {
-        console.log('✅ Dashboard cache refreshed for guild leave')
-      } else {
-        console.error(
-          '⚠️ Dashboard refresh failed:',
-          response.status,
-          await response.text()
-        )
-      }
-    } catch (err) {
-      console.error('❌ Failed to refresh dashboard cache:', err.message)
-    }
-  }
+  await notifyDashboard(client, guild.id, 'leave')
 
   let ownerTag = 'Deleted User'
   const ownerId = guild.ownerId || settings.server.owner
@@ -56,9 +29,9 @@ module.exports = async (client, guild) => {
   try {
     owner = await client.users.fetch(ownerId)
     ownerTag = owner.tag
-    console.log(`Fetched owner: ${ownerTag}`)
+    client.logger.log(`Fetched owner: ${ownerTag}`)
   } catch (err) {
-    console.error(`Failed to fetch owner: ${err.message}`)
+    client.logger.error(`Failed to fetch owner: ${err.message}`)
   }
 
   // Create the embed for webhook
@@ -100,12 +73,12 @@ module.exports = async (client, guild) => {
         avatarURL: client.user.displayAvatarURL(),
         embeds: [webhookEmbed],
       })
-      console.log('Successfully sent webhook message for guild leave event.')
+      client.logger.success('Successfully sent webhook message for guild leave event.')
     } catch (err) {
-      console.error(`Failed to send webhook message: ${err.message}`)
+      client.logger.error(`Failed to send webhook message: ${err.message}`)
     }
   } else {
-    console.log('Join/Leave webhook is not configured.')
+    client.logger.warn('Join/Leave webhook is not configured.')
   }
 
   // Attempt to send DM to owner
@@ -150,24 +123,24 @@ module.exports = async (client, guild) => {
 
     try {
       await wait(1000)
-      console.log(`Attempting to send DM to owner: ${ownerId}`)
+      client.logger.log(`Attempting to send DM to owner: ${ownerId}`)
 
       await owner.send({
         embeds: [dmEmbed],
         components: [row],
       })
 
-      console.log('Successfully sent goodbye DM to the server owner.')
+      client.logger.success('Successfully sent goodbye DM to the server owner.')
     } catch (err) {
-      console.error(`Error sending DM: ${err.message}`)
+      client.logger.error(`Error sending DM: ${err.message}`)
       if (err.code === 50007) {
-        console.error(
+        client.logger.error(
           'Cannot send messages to this user. They may have DMs disabled or blocked the bot.'
         )
       }
     }
   } else {
-    console.log(
+    client.logger.warn(
       'Unable to send DM to owner as owner information is not available.'
     )
   }

--- a/src/helpers/webhook.js
+++ b/src/helpers/webhook.js
@@ -1,0 +1,47 @@
+/**
+ * Notify the dashboard to refresh guild data
+ * @param {import('@src/structures').BotClient} client - The Discord bot client
+ * @param {string} guildId - The guild ID to refresh
+ * @param {string} eventType - The event type ('join' or 'leave')
+ * @returns {Promise<void>}
+ */
+async function notifyDashboard(client, guildId, eventType = 'refresh') {
+  if (!process.env.BASE_URL || !process.env.WEBHOOK_SECRET) {
+    return
+  }
+
+  try {
+    // Create abort controller with 10 second timeout
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 10000)
+
+    const response = await fetch(`${process.env.BASE_URL}/api/guild/refresh`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.WEBHOOK_SECRET}`,
+      },
+      body: JSON.stringify({ guildId }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+
+    if (response.ok) {
+      client.logger.success(`Dashboard notified of guild ${eventType}`)
+    } else {
+      const errorText = await response.text()
+      client.logger.error(
+        `Dashboard webhook failed (${response.status}): ${errorText}`
+      )
+    }
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      client.logger.error('Dashboard webhook timed out after 10 seconds')
+    } else {
+      client.logger.error(`Failed to notify dashboard: ${err.message}`)
+    }
+  }
+}
+
+module.exports = { notifyDashboard }

--- a/src/helpers/webhook.js
+++ b/src/helpers/webhook.js
@@ -6,7 +6,7 @@
  * @returns {Promise<void>}
  */
 async function notifyDashboard(client, guildId, eventType = 'refresh') {
-  if (!process.env.BASE_URL || !process.env.WEBHOOK_SECRET) {
+  if (!process.env.BASE_URL?.trim() || !process.env.WEBHOOK_SECRET?.trim()) {
     return
   }
 


### PR DESCRIPTION
## 🎯 Summary
This PR adds real-time synchronization between the bot and dashboard by sending webhook notifications whenever the bot joins or leaves a guild.

## ✨ Changes

### 1. **Environment Configuration** (`.env.example`)
- Added `BASE_URL` documentation - Dashboard URL (e.g., `https://yoursite.com`)
- Added `WEBHOOK_SECRET` - Secure random string for webhook authentication
- Reuses existing `BASE_URL` instead of creating a separate `DASHBOARD_WEBHOOK_URL`

### 2. **Guild Leave Event** (`src/events/guild/guildDelete.js`)
- Added webhook notification after updating database `leftAt` timestamp
- Sends `guildId` to dashboard at `BASE_URL/api/guild/refresh`
- Non-blocking error handling - bot continues normally if webhook fails
- Logs success/failure for debugging

### 3. **Guild Join Event** (`src/events/guild/guildCreate.js`)
- Added webhook notification after saving guild settings
- Sends `guildId` to dashboard to clear `leftAt` field
- Non-blocking error handling
- Logs success/failure for debugging

## 🔒 Security
- Uses Bearer token authentication with `WEBHOOK_SECRET`
- Webhook failures don't affect bot operation
- Dashboard validates authentication before processing events

## 🧪 Testing

### Setup
1. Add to `.env`:
   ```env
   BASE_URL=http://localhost:4321
   WEBHOOK_SECRET=b49321acfb60318dd652ab747eb3f766356c2e258d67a4a22a5f14d77df4d43c
   ```
2. Ensure dashboard is running and has the same `WEBHOOK_SECRET`

### Test Cases
- ✅ Bot joins a server → Dashboard receives webhook → Discord API checked → `leftAt` updated if needed
- ✅ Bot leaves a server → Dashboard receives webhook → Discord API checked → `leftAt` updated
- ✅ Webhook failure (dashboard down) → Bot continues normally, logs error
- ✅ Invalid webhook secret → Dashboard returns 401, bot logs error

### Expected Console Logs
```
✅ Dashboard notified of guild join
✅ Dashboard notified of guild leave
```

Or on failure:
```
⚠️ Dashboard webhook failed: 401 Unauthorized
❌ Failed to notify dashboard of guild join: Connection refused
```

## 📊 Impact
- **Dashboard stays in sync** - No stale data showing bot in servers it left
- **Better UX** - Users see accurate "Add Bot" vs "Manage" buttons
- **Instant updates** - No waiting for manual refresh
- **Backward compatible** - Works even if `BASE_URL` or `WEBHOOK_SECRET` not set
- **Single source of truth** - Discord API determines actual bot presence (via refresh endpoint)

## 🔗 Related
- Dashboard webhook endpoint: `/api/guild/refresh` (unified endpoint for both manual and webhook refresh)
- Endpoint accepts JSON with Bearer token authentication
- Rate limiting: 5 min guild cooldown, 10 attempts/min per user (manual only)

## 📝 Notes
- Webhook is **optional** - bot works normally even if dashboard is down
- Uses existing `BASE_URL` environment variable
- Minimal performance impact (~50ms per join/leave event)
- Falls back gracefully if dashboard unavailable
- Dashboard checks Discord API to verify actual bot presence (eliminates redundant updates)














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-time sync between the bot and the dashboard by sending webhooks on guild join/leave. Keeps guild status accurate instantly without waiting for a refresh.

- **New Features**
  - POST to BASE_URL/api/guild/refresh on guildCreate and guildDelete with guildId (JSON).
  - Authenticated via Bearer WEBHOOK_SECRET; failures are logged and non-blocking.
  - Reuses BASE_URL for the dashboard; no separate webhook URL.
  - Adds a webhook helper with a 10s timeout for safer network calls.

- **Migration**
  - Set BASE_URL to your dashboard origin.
  - Add WEBHOOK_SECRET to both the bot and the dashboard (must match).

<sup>Written for commit 1d8edfc6e5e91afb3af243743754323cc7ffa973. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard synchronization now notifies the external dashboard when the app joins or leaves a guild.

* **Configuration**
  * Added BASE_URL and WEBHOOK_SECRET environment variables to enable authenticated dashboard webhook calls.

* **Improvements**
  * More robust webhook requests (with timeout handling) and clearer, structured logging for guild join/leave and webhook operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->