### PR TITLE
chore: update advanced-git-sync version and bump lavalink-client depe…

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6.0.0
 
       - name: Sync with GitLab
-        uses: OpenSaucedHub/advanced-git-sync@v1.4.8
+        uses: OpenSaucedHub/advanced-git-sync@v1.4.9
         with:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -612,7 +612,7 @@
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
-    "lavalink-client": ["lavalink-client@2.6.7", "", { "dependencies": { "tslib": "^2.8.1", "ws": "^8.18.3" } }, "sha512-y/7ML+caiqqe+9TDKfJyV1y10nrbGo3Csk/Eq7+y4+bG5gMcbbcQ/I3h85unJr3pcfvIyyaBts0yeglfI4vo7A=="],
+    "lavalink-client": ["lavalink-client@2.7.0", "", { "dependencies": { "tslib": "^2.8.1", "ws": "^8.18.3" } }, "sha512-Q5oJYFDZAsvCCUiNd4xlGExNlUDTstlP6G3lOlxmLuvaXTkMRQW2yeAme72yMiE4tLOA+a13QzWHWDNTVsIiSg=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "f": "prettier --write .",
     "f:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "typecheck:watch": "tsc --noEmit --watch",
-    "prepare": "husky"
+    "typecheck:watch": "tsc --noEmit --watch"
   },
   "homepage": "https://github.com/iamvikshan/amina#readme",
   "repository": {
@@ -40,7 +39,7 @@
     "discord.js": "^14.25.1",
     "enhanced-ms": "^4.1.0",
     "fixedsize-map": "^1.1.0",
-    "lavalink-client": "^2.6.7",
+    "lavalink-client": "^2.7.0",
     "module-alias": "^2.2.3",
     "moment": "^2.30.1",
     "mongoose": "^8.20.1",


### PR DESCRIPTION
…ndency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the GitLab sync workflow to advanced-git-sync v1.4.9 and bump lavalink-client to ^2.7.0 to stay current. Removed the Husky prepare script from package.json.

<sup>Written for commit a7eabcc74377dc374f597ee2b36a59ed60d280c1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Infrastructure and dependency updates have been made in this release.

* **Chores**
  * Updated the GitHub Actions sync workflow action from version 1.4.8 to 1.4.9
  * Updated the lavalink-client dependency from version 2.6.7 to 2.7.0
  * Removed the automatic setup preparation script from the development configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->